### PR TITLE
Missing Python Requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ scipy>=1.1.0
 numpy>=1.15.4
 torch>=1.0.0
 pycapnp
+numba


### PR DESCRIPTION
I found that I needed the `numba` package in order to build/install DREAMPlaceFPGA.