### PR TITLE
[IFWriter] Both LUT6_2/LUT{5,6} cells are mapped to ?6LUT bel

### DIFF
--- a/dreamplacefpga/IFWriter.py
+++ b/dreamplacefpga/IFWriter.py
@@ -2037,6 +2037,9 @@ class db_to_physicalnetlist():
                             bel_name = self.Map_bel(z, node_type)
                         else:
                             bel_name = cell_type
+
+                        if cell_name.startswith('LUT6_2_0/'):
+                            print('** FIXME **', cell_name, 'of node_type=' +  node_type, 'inst=' + inst, 'mapped onto', site_name + '/' + bel_name)
                             
                         self.node_site_map[node_name] = site_name
 

--- a/test/gnl_2_4_3_1.3_gnl_3000_07_3_80_80.json
+++ b/test/gnl_2_4_3_1.3_gnl_3000_07_3_80_80.json
@@ -1,6 +1,6 @@
 {
     "aux_input" : "benchmarks/IF2bookshelf/gnl_2_4_3_1.3_gnl_3000_07_3_80_80/design.aux", 
-    "gpu" : 1,
+    "gpu" : 0,
     "num_bins_x" : 512,
     "num_bins_y" : 512,
     "global_place_stages" : [
@@ -15,8 +15,8 @@
     "detailed_place_flag" : 0,
     "dtype" : "float32",
     "plot_flag" : 0,
-    "num_threads" : 6,
-    "deterministic_flag" : 0,
+    "num_threads" : 1,
+    "deterministic_flag" : 1,
     "enable_if" : 1,
     "part_name" : "xcvu3p-ffvc1517-2-e"
     }


### PR DESCRIPTION
With this PR, running:
```
$ python dreamplacefpga/Placer.py test/gnl_2_4_3_1.3_gnl_3000_07_3_80_80.json
```
the last few lines of the output are deterministically:
```
[INFO   ] DREAMPlaceFPGA - Completed Placement in 189.732 seconds
[INFO   ] DREAMPlaceFPGA - Start writing solution to Interchange Format(IF)
** FIXME ** LUT6_2_0/LUT5 of node_type=LUT6_2 inst=LUT5 mapped onto SLICE_X75Y143/H6LUT
** FIXME ** LUT6_2_0/LUT6 of node_type=LUT6_2 inst=LUT6 mapped onto SLICE_X75Y143/H6LUT
[INFO   ] DREAMPlaceFPGA - Interchange Format(IF) Writer completed in 27.262 seconds
```
showing that both LUT5 and LUT6 cells are mapped onto the H6LUT BEL.

The expected result should be H5LUT and H6LUT respectively.