### PR TITLE
[IFWriter] SRST{1,2} site pins on VCC net even if no FFs in SLICE

### DIFF
--- a/dreamplacefpga/IFWriter.py
+++ b/dreamplacefpga/IFWriter.py
@@ -607,6 +607,9 @@ class SiteInst():
                     child2 = routing_graph[child]
                     site_routing[child2] = []
                     net_roots[child2] = constant_nets[0]
+                    if self.name == 'SLICE_X67Y156':
+                        print('** FIXME **', self.name + ':', 'rst_in='+str(rst_in), 'connects to', constant_nets[1], 'child='+str(child), 'child2='+str(child2), 'connect to', constant_nets[0])
+
             
             net_roots[gnd_tup] = constant_nets[0]
             site_routing[gnd_tup] = []


### PR DESCRIPTION
Single case of SRST{1,2} site pins being attached to the GLOBAL_LOGIC1 (vcc) net even if there are no FFs in SLICEs (just one shown below).

Last few lines of:
```
$ python dreamplacefpga/Placer.py test/gnl_2_4_3_1.3_gnl_3000_07_3_80_80.json
```
are:
```
[INFO   ] DREAMPlaceFPGA - Completed Placement in 190.115 seconds
[INFO   ] DREAMPlaceFPGA - Start writing solution to Interchange Format(IF)
** FIXME ** SLICE_X67Y156: rst_in=('bel_pin', 'SRST1', 'SRST1') connects to GLOBAL_LOGIC1 child=('site_pip', 'RST_ABCDINV', 'RST') child2=('bel_pin', 'RST_ABCDINV', 'OUT') connect to GLOBAL_LOGIC0
** FIXME ** SLICE_X67Y156: rst_in=('bel_pin', 'SRST2', 'SRST2') connects to GLOBAL_LOGIC1 child=('site_pip', 'RST_EFGHINV', 'RST') child2=('bel_pin', 'RST_EFGHINV', 'OUT') connect to GLOBAL_LOGIC0
[INFO   ] DREAMPlaceFPGA - Interchange Format(IF) Writer completed in 26.349 seconds
```

Specifically, it looks like the `SRST{1,2}` bel pin is being set to VCC, the `RST_{ABCD,EFGH}INV` Site PIP is turned on, and the `RST_{ABCD,EFGH}INV/OUT`  bel pin is being set to GND.

Note that `SRST1` services the lower eight flops (`[A-D]FF{,2}`) and `SRST2` the upper. It is possible that either or both need those connections, depending on if any FF appears in its half.